### PR TITLE
Removed 'application' element from AndroidManifest.xml.

### DIFF
--- a/r2-opds/src/main/AndroidManifest.xml
+++ b/r2-opds/src/main/AndroidManifest.xml
@@ -7,13 +7,4 @@
   ~ LICENSE file present in the project repository where this source code is maintained.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.readium.r2.opds"
-    xmlns:tools="http://schemas.android.com/tools">
-
-    <application
-        android:allowBackup="false"
-        android:supportsRtl="true"
-        tools:replace="android:allowBackup"/>
-
-</manifest>
+<manifest package="org.readium.r2.opds" />


### PR DESCRIPTION
The library manifest had defined the attributes 'allowBackup'
and 'supportsRtl'. This may result in a manifest merge error
requiring implementors to use an override like 'tools:replace'.