### PR TITLE
Add a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+**Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with caution.
+
+## [Unreleased]
+
+### Changed
+
+* Update internal usage of the `Publication` shared models.
+
+### Fixed
+
+* XML namespace prefixes are now properly supported when an author chooses unusual ones (contributed by [@qnga](https://github.com/readium/r2-shared-kotlin/pull/85)).
+* The `AndroidManifest.xml` is not forcing anymore `allowBackup` and `supportsRtl`, to let reading apps manage these features themselves (contributed by [@twaddington](https://github.com/readium/r2-opds-kotlin/pull/41)).
+
+
+[unreleased]: https://github.com/readium/r2-opds-kotlin/compare/master...HEAD
+[x.x.x]: https://github.com/readium/r2-opds-kotlin/compare/1.1.4...x.x.x

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 A parser for OPDS 1.x and 2.0 written in Kotlin using the [Readium-2 shared model](https://github.com/readium/r2-shared-kotlin) 
 and [Readium Web Publication Manifest](https://github.com/readium/webpub-manifest).
 
+[Changes and releases are documented in the Changelog](CHANGELOG.md)
+
 ## Features
 
 - [x] Abstract model


### PR DESCRIPTION
Add a changelog to document all notable changes and releases.

Strongly inspired by the format specified by [Keep a Changelog](https://keepachangelog.com/).