### PR TITLE
Add new functions that use HttpRequest and Try to eventually replace Fuel and Promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 
 **Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with caution.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+* New APIs using coroutines and R2's `HttpClient` instead of Fuel and kovenant (contributed by [@stevenzeck](https://github.com/readium/r2-opds-kotlin/pull/55)).
 
 ## [2.0.0]
 

--- a/r2-opds/build.gradle
+++ b/r2-opds/build.gradle
@@ -43,11 +43,10 @@ dependencies {
     }
 
     implementation "androidx.appcompat:appcompat:1.3.0-beta1"
-    implementation "com.github.kittinunf.fuel:fuel-android:2.2.2"
-    implementation "com.github.kittinunf.fuel:fuel:2.2.2"
     implementation "com.jakewharton.timber:timber:4.7.1"
     implementation "joda-time:joda-time:2.10.5"
     implementation "nl.komponents.kovenant:kovenant:3.3.0"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3"
 
     testImplementation "junit:junit:4.13.2"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"

--- a/r2-opds/src/main/java/org/readium/r2/opds/Extensions.kt
+++ b/r2-opds/src/main/java/org/readium/r2/opds/Extensions.kt
@@ -13,6 +13,6 @@ import org.readium.r2.shared.util.http.HttpClient
 import org.readium.r2.shared.util.http.HttpFetchResponse
 import org.readium.r2.shared.util.http.HttpRequest
 
-fun HttpClient.fetchPromise(request: HttpRequest): Promise<HttpFetchResponse, Exception> {
+internal fun HttpClient.fetchPromise(request: HttpRequest): Promise<HttpFetchResponse, Exception> {
     return task { runBlocking { fetch(request).getOrThrow() } }
 }

--- a/r2-opds/src/main/java/org/readium/r2/opds/Extensions.kt
+++ b/r2-opds/src/main/java/org/readium/r2/opds/Extensions.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 Readium Foundation. All rights reserved.
+ * Use of this source code is governed by the BSD-style license
+ * available in the top-level LICENSE file of the project.
+ */
+
+package org.readium.r2.opds
+
+import kotlinx.coroutines.runBlocking
+import nl.komponents.kovenant.Promise
+import nl.komponents.kovenant.task
+import org.readium.r2.shared.util.http.HttpClient
+import org.readium.r2.shared.util.http.HttpFetchResponse
+import org.readium.r2.shared.util.http.HttpRequest
+
+fun HttpClient.fetchPromise(request: HttpRequest): Promise<HttpFetchResponse, Exception> {
+    return task { runBlocking { fetch(request).getOrThrow() } }
+}

--- a/r2-opds/src/main/java/org/readium/r2/opds/OPDS2Parser.kt
+++ b/r2-opds/src/main/java/org/readium/r2/opds/OPDS2Parser.kt
@@ -9,19 +9,18 @@
 
 package org.readium.r2.opds
 
-import com.github.kittinunf.fuel.Fuel
 import nl.komponents.kovenant.Promise
 import nl.komponents.kovenant.then
 import org.joda.time.DateTime
 import org.json.JSONArray
 import org.json.JSONObject
 import org.readium.r2.shared.opds.*
-import org.readium.r2.shared.promise
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Manifest
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.util.Try
 import org.readium.r2.shared.util.http.DefaultHttpClient
+import org.readium.r2.shared.util.http.HttpClient
 import org.readium.r2.shared.util.http.HttpRequest
 import org.readium.r2.shared.util.http.fetchWithDecoder
 import java.net.URL
@@ -40,48 +39,38 @@ class OPDS2Parser {
 
         private lateinit var feed: Feed
 
-        suspend fun parseUrlString(url: String): Try<ParseData, Exception> {
-            return DefaultHttpClient().fetchWithDecoder(HttpRequest(url)) {
+        suspend fun parseUrlString(url: String, client: HttpClient = DefaultHttpClient()): Try<ParseData, Exception> {
+            return client.fetchWithDecoder(HttpRequest(url)) {
                 this.parse(it.body, URL(url))
             }
         }
 
+        suspend fun parseRequest(request: HttpRequest, client: HttpClient = DefaultHttpClient()): Try<ParseData, Exception> {
+            return client.fetchWithDecoder(request) {
+                this.parse(it.body, URL(request.url))
+            }
+        }
+
         @Deprecated(
-            "Use `parseUrlString` with coroutines and pass a string for the URL instead",
+            "Use `parseRequest` or `parseUrlString` with coroutines instead",
             ReplaceWith("OPDS2Parser.parseUrlString(url)"),
             DeprecationLevel.WARNING
         )
         fun parseURL(url: URL): Promise<ParseData, Exception> {
-            return Fuel.get(url.toString(), null).promise() then {
-                val (_, _, result) = it
-                this.parse(result, url)
-            }
-        }
-
-        suspend fun parseUrlString(
-            url: String,
-            headers: MutableMap<String, String>
-        ): Try<ParseData, Exception> {
-            return DefaultHttpClient().fetchWithDecoder(
-                HttpRequest(
-                    url = url,
-                    headers = headers
-                )
-            ) {
-                this.parse(it.body, URL(url))
+            return DefaultHttpClient().fetchPromise(HttpRequest(url.toString())) then {
+                this.parse(it.body, url)
             }
         }
 
         @Deprecated(
-            "Use `parseUrlString` with coroutines and pass a string for the URL instead",
-            ReplaceWith("OPDS2Parser.parseUrlString(url, headers)"),
+            "Use `parseRequest` or `parseUrlString` with coroutines instead",
+            ReplaceWith("OPDS2Parser.parseUrlString(url)"),
             DeprecationLevel.WARNING
         )
         @Suppress("unused")
-        fun parseURL(headers:MutableMap<String,String>, url: URL): Promise<ParseData, Exception> {
-            return Fuel.get(url.toString(), null).header(headers).promise() then {
-                val (_, _, result) = it
-                this.parse(result, url)
+        fun parseURL(headers: MutableMap<String,String>, url: URL): Promise<ParseData, Exception> {
+            return DefaultHttpClient().fetchPromise(HttpRequest(url = url.toString(), headers = headers)) then {
+                this.parse(it.body, url)
             }
         }
 

--- a/r2-opds/src/main/java/org/readium/r2/opds/OPDS2Parser.kt
+++ b/r2-opds/src/main/java/org/readium/r2/opds/OPDS2Parser.kt
@@ -20,6 +20,10 @@ import org.readium.r2.shared.promise
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Manifest
 import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.util.Try
+import org.readium.r2.shared.util.http.DefaultHttpClient
+import org.readium.r2.shared.util.http.HttpRequest
+import org.readium.r2.shared.util.http.fetchWithDecoder
 import java.net.URL
 
 enum class OPDS2ParserError {
@@ -36,6 +40,17 @@ class OPDS2Parser {
 
         private lateinit var feed: Feed
 
+        suspend fun parseUrlString(url: String): Try<ParseData, Exception> {
+            return DefaultHttpClient().fetchWithDecoder(HttpRequest(url)) {
+                this.parse(it.body, URL(url))
+            }
+        }
+
+        @Deprecated(
+            "Use `parseUrlString` with coroutines and pass a string for the URL instead",
+            ReplaceWith("OPDS2Parser.parseUrlString(url)"),
+            DeprecationLevel.WARNING
+        )
         fun parseURL(url: URL): Promise<ParseData, Exception> {
             return Fuel.get(url.toString(), null).promise() then {
                 val (_, _, result) = it
@@ -43,6 +58,25 @@ class OPDS2Parser {
             }
         }
 
+        suspend fun parseUrlString(
+            url: String,
+            headers: MutableMap<String, String>
+        ): Try<ParseData, Exception> {
+            return DefaultHttpClient().fetchWithDecoder(
+                HttpRequest(
+                    url = url,
+                    headers = headers
+                )
+            ) {
+                this.parse(it.body, URL(url))
+            }
+        }
+
+        @Deprecated(
+            "Use `parseUrlString` with coroutines and pass a string for the URL instead",
+            ReplaceWith("OPDS2Parser.parseUrlString(url, headers)"),
+            DeprecationLevel.WARNING
+        )
         @Suppress("unused")
         fun parseURL(headers:MutableMap<String,String>, url: URL): Promise<ParseData, Exception> {
             return Fuel.get(url.toString(), null).header(headers).promise() then {


### PR DESCRIPTION
This PR creates new functions that use the DefaultHttpClient and Try to eventually replace the existing ones that use Fuel and Promises.

- The two `parseUrlString` functions are the replacements for the `parseURL` ones (applicable to OPDS1Parser and OPDS2Parser)
- Instead of accepting a URL, it accepts a String and an optional HttpClient (both)
- `retrieveOpenSearchTemplate` is the replacement for `fetchOpenSearchTemplate` (OPDS1Parser)
- For Instead of returning a Promise, it returns a Try (both)
- `parseURL` and `fetchOpenSearchTemplate` are both marked as deprecated with a warning (both)
- New function, `parseRequest`, that accepts an HttpRequest and an optional HttpClient
- Deprecated functions use the DefaultHttpClient, replacing Fuel, thus removing Fuel as a dependency

I took the liberty of naming the new functions, but feel free to change them.